### PR TITLE
Drop dependency on Copy Relative Path extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "xabikos.JavaScriptSnippets",
     "christian-kohler.npm-intellisense",
     "wmaurer.vscode-jumpy",
-    "alexdima.copy-relative-path",
     "CoenraadS.bracket-pair-colorizer",
     "sdras.night-owl"
   ]


### PR DESCRIPTION
- Since VSCode has absorbed CRP as a built-in feature in v1.26, drop the dependency on CRP extension

Refs: https://code.visualstudio.com/updates/v1_26#_copy-relative-path
Fixes: https://github.com/sdras/vue-vscode-extensionpack/issues/3