### PR TITLE
add vscode-goto-node-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ These are some of my favorite extensions to make Vue application development eas
 - [NPM Intellisense](https://marketplace.visualstudio.com/items?itemName=christian-kohler.npm-intellisense&WT.mc_id=marketplace-pack-sdras) - a plugin that autocompletes npm modules in import statements
 - [ES6 Snippets](https://marketplace.visualstudio.com/items?itemName=xabikos.JavaScriptSnippets&WT.mc_id=marketplace-pack-sdras) - quickly spin up ES6 JavaScript with only 3 or 4 characters
 - [Night Owl](https://marketplace.visualstudio.com/items?itemName=sdras.night-owl&WT.mc_id=marketplace-pack-sdras) Syntax highlighting can be a very personal thing, so you might not want to use this, but I worked hard creating a theme you might like. Especially great for your eyes at night, this theme was developed especially with contrast and colorblindness in mind.
+- [goto node modules](https://marketplace.visualstudio.com/items?itemName=ravenq.vscode-goto-node-modules) - Goto node modules from vue/js code.
 
 ## Relevant Links
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "christian-kohler.npm-intellisense",
     "wmaurer.vscode-jumpy",
     "CoenraadS.bracket-pair-colorizer",
-    "sdras.night-owl"
+    "sdras.night-owl",
+    "ravenq.vscode-goto-node-modules"
   ]
 }


### PR DESCRIPTION
Hi.

I publish a plugin in the marketplace: https://marketplace.visualstudio.com/items?itemName=ravenq.vscode-goto-node-modules.

and want add this plugin to the pack.

The plugin make it easy to goto the dependence pack in the node_modules fold like goto definition.

Thanks!